### PR TITLE
Partial upload was failing

### DIFF
--- a/ob-ml-common.el
+++ b/ob-ml-common.el
@@ -122,7 +122,9 @@ The code is executed by passing it to MarkLogic for evaluation."
       (save-match-data
         (delete-trailing-whitespace)
         (goto-char (point-min))
-        (if (search-forward "upload completely sent off")
+        (while (or 
+                (search-forward "upload completely sent off" nil t)
+                (search-forward "completely uploaded and fine" nil t))
             (progn
               (beginning-of-line)
               (forward-line)


### PR DESCRIPTION
I was seeing failures with multi-part uploads;  modifying the conditional resolved them.  I changed it to a while because I couldn't figure out how to get an if to work properly.

Looking at the curl code, it looks like the message "We are completely uploaded and fine" is sent when the data is completely sent with a multipart upload.

I'm on a Mac, with curl 7.49.1 (x86_64-apple-darwin16.0) libcurl/7.49.1 SecureTransport zlib/1.2.8